### PR TITLE
Get rid of dangerous "rm -rf *"

### DIFF
--- a/make_ncep_libs.sh
+++ b/make_ncep_libs.sh
@@ -120,7 +120,8 @@ make || fail "An error occurred building the NCEP libraries"
 echo
 echo "Installing to ${NCEPLIBS_DST_DIR} ..."
 echo
-rm -fr ${NCEPLIBS_DST_DIR}/*
+rm -fr ${NCEPLIBS_DST_DIR}/lib
+rm -fr ${NCEPLIBS_DST_DIR}/include
 mkdir ${NCEPLIBS_DST_DIR}/lib
 mkdir ${NCEPLIBS_DST_DIR}/include
 cp -av ${BUILD_DIR}/include/* ${NCEPLIBS_DST_DIR}/include/


### PR DESCRIPTION
Currently the script `make_ncep_libs.sh` clobbers the old build with the command 

   rm -fr ${NCEPLIBS_DST_DIR}/*

This is not only undesirable (I lost a lot of work that I had temporarily stored in that directory) it's incredibly dangerous, since NCEPLIBS_DST_DIR comes from a command line argument and a simple user error could lead to the loss of a *lot* of data. A safer (but still not ideal) way to go about this would be to specify the exact directories to be deleted:

    rm -fr ${NCEPLIBS_DST_DIR}/lib
    rm -fr ${NCEPLIBS_DST_DIR}/include

It may also be worth adding a check and a user prompt prior to deletion.